### PR TITLE
Added Todo Page; Updated Build; Added Points/Review for Clean Arch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+tab_width = 4

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,7 @@
 {
+  "MD007": {
+    "indent": 4
+  },
   "MD013": {
     "code_blocks": false,
     "headers": false,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,14 +8,21 @@ printf "Copying assets\n"
 cp src/assets/* dist/
 
 printf "Converting md to HTML\n"
-CONVERTED_MARKDOWN=`./node_modules/.bin/showdown makehtml -i src/bookshelf.md`
+CONVERTED_BOOKSHELF_MARKDOWN=`./node_modules/.bin/showdown makehtml -i src/bookshelf.md`
+CONVERTED_TODO_MARKDOWN=`./node_modules/.bin/showdown makehtml -i src/todo.md`
 
 printf "Injecting HTML\n"
-sed -i "/%CONTENT%/a $(echo $CONVERTED_MARKDOWN)" dist/index.html
+sed -i "/%CONTENT%/a $(echo $CONVERTED_BOOKSHELF_MARKDOWN)" dist/index.html
 sed -i "/%CONTENT%/d" dist/index.html
+sed -i "/%CONTENT%/a $(echo $CONVERTED_TODO_MARKDOWN)" dist/todo.html
+sed -i "/%CONTENT%/d" dist/todo.html
+
+printf "Converting Emojis\n"
+sed -i "s/:books:/📚/g" dist/index.html
 
 printf "Minifying HTML\n"
 ./node_modules/.bin/html-minifier --config-file .html-minifier.json --output dist/index.html dist/index.html
+./node_modules/.bin/html-minifier --config-file .html-minifier.json --output dist/todo.html dist/todo.html
 
 printf "Minifying CSS\n"
 ./node_modules/.bin/cleancss -O 1 --output dist/style.css dist/style.css

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -94,10 +94,6 @@ h2 {
   border-bottom: 2px dotted rgba(51,51,51,0.08);
 }
 
-h3::before {
-  content: "📚";
-}
-
 
 
 

--- a/src/assets/todo.html
+++ b/src/assets/todo.html
@@ -7,16 +7,16 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
   <link rel="stylesheet" href="./style.css">
-  <title>Vapurrmaid | Noteworthy Books & Articles</title>
+  <title>Vapurrmaid | Books To Be Read, Reviewed</title>
 </head>
 
 <body class="container">
 
   <header>
-    <h1>Noteworthy Books & Articles</h1>
+    <h1>To Do</h1>
 
-    <p>A personalized collection of noteworthy abooks, articles and other texts. Items I have not yet read or reviewed
-      are kept on my <a href="todo.html">todo list</a>.</p>
+    <p>Items I'm in the process of reviewing or want to read. Items I have read/reviewed are kept on my <a
+        href="index.html">Noteworthy Texts</a> page.</p>
   </header>
 
   <main>

--- a/src/bookshelf.md
+++ b/src/bookshelf.md
@@ -1,9 +1,43 @@
 ## 2020
 
-### Clean Architecture
+### :books: Clean Architecture
 
 R. C. Martin, *Clean Architecture: A Craftsman's Guide to Software Structure and Design*. Prentice Hall,
 2017.
+
+#### Key Points
+
+##### Goals and Importance of Architecture/Design/Structure
+
+- the goal of architecture is to *minimize* human resources
+- *structure* is more valuable than behaviour, because it imposes/dictates it
+- start/stay *clean*: you won't have time to go back (only way to go fast is to go well)
+
+##### Software is both consistent and ever-changing
+
+- Code/programming has changed very little (by contrast, tools and processing have)
+- architectural rules are *consistent*, even across system types and time
+- software is *soft*; design for change intentionally
+
+##### Programming in the small and large
+
+- proper functional decomposition applied at all levels keeps everything *testable*
+- paradigms impose *discipline*
+    - structured paradigm imposes disciplined use of direct transfer of control (`goto`)
+    - OO paradigm imposes disciplined use of indirect transfer of control (polymorphism)
+    - functional paradigm imposes disciplined use of assignment (mutability)
+- polymorphic *plugins*; programs should be device (detail) independent
+- *dependency inversion* can be applied anywhere to control direction of dependents
+- Segregate *immutable* (functional) components from immutable ones
+
+#### Review
+
+Robert Martin's "Clean Architecture" offers *solid* advice in building systems while offering little
+in terms of concrete code examples and architectural blueprints. Indeed, the end of the book contains
+a short chapter unveiling what's commonly considered as "The Onion Architecture", but this reveal feels
+like an aftermath more than the main punch. Instead, the book succeeds at defining architecture and its
+goals, along with well-depicted descriptions, metrics and elements that are used to design and
+evaluate software systems.
 
 ## 2019
 
@@ -15,15 +49,15 @@ Overall, I gained an appreciation for:
 - designing objects for change (this is a common motif in enterprise)
 - handling legacy systems and major codebase changes
 
-### Domain Driven Design
+### :books: Domain Driven Design
 
 E. Evans, *Domain-Driven Design: Tackling Complexity in the Heart of Software*. Addison-Wesley, 2004.
 
-### Patterns of Enterprise Application Architecture
+### :books: Patterns of Enterprise Application Architecture
 
 M. Fowler, *Patterns of Enterprise Application Architecture*, Addison-Wesley Professional, 2002.
 
-### Refactoring
+### :books: Refactoring
 
 M. Fowler, *Refactoring: Improving the Design of Existing Code*, 2nd ed. Addison-Wesley
 Professional, 2018.

--- a/src/bookshelf.md
+++ b/src/bookshelf.md
@@ -13,13 +13,13 @@ R. C. Martin, *Clean Architecture: A Craftsman's Guide to Software Structure and
 - *structure* is more valuable than behaviour, because it imposes/dictates it
 - start/stay *clean*: you won't have time to go back (only way to go fast is to go well)
 
-##### Software is both consistent and ever-changing
+##### Software is Both Consistent and Always Changing
 
 - Code/programming has changed very little (by contrast, tools and processing have)
 - architectural rules are *consistent*, even across system types and time
 - software is *soft*; design for change intentionally
 
-##### Programming in the small and large
+##### Programming in the Small and Large
 
 - proper functional decomposition applied at all levels keeps everything *testable*
 - paradigms impose *discipline*

--- a/src/bookshelf.md
+++ b/src/bookshelf.md
@@ -15,19 +15,19 @@ R. C. Martin, *Clean Architecture: A Craftsman's Guide to Software Structure and
 
 ##### Software is Both Consistent and Always Changing
 
-- Code/programming has changed very little (by contrast, tools and processing have)
-- architectural rules are *consistent*, even across system types and time
+- programming has changed very little (by contrast, tools and processing have)
+    - architectural rules are *consistent*, even across systems and time
 - software is *soft*; design for change intentionally
 
 ##### Programming in the Small and Large
 
-- proper functional decomposition applied at all levels keeps everything *testable*
+- **functional decomposition** applied at all levels keeps everything *testable*
 - paradigms impose *discipline*
-    - structured paradigm imposes disciplined use of direct transfer of control (`goto`)
-    - OO paradigm imposes disciplined use of indirect transfer of control (polymorphism)
-    - functional paradigm imposes disciplined use of assignment (mutability)
-- polymorphic *plugins*; programs should be device (detail) independent
-- *dependency inversion* can be applied anywhere to control direction of dependents
+    - **structured paradigm** imposes disciplined use of direct transfer of control (`goto`)
+    - **OO** imposes disciplined use of indirect transfer of control (polymorphism)
+    - **functional paradigm** imposes disciplined use of assignment (mutability)
+- **plugins** via polymorphism; design for device (detail) independence
+- **dependency inversion** can be applied anywhere to control direction of dependents
 - Segregate *immutable* (functional) components from immutable ones
 
 #### Review

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,0 +1,18 @@
+## To Be Reviewed
+
+- Building Microservices (Newman)
+- Domain Driven Design (Evans)
+- Patterns of Enterprise Application Architecture (Fowler)
+- Refactoring (Fowler)
+
+## To Read
+
+- Dietrich, E., 2017. Developer Hegemony: The Future Of Labor. Daedtech.
+- Gamma, E., 1995. Design Patterns: Elements Of Reusable Object-oriented Software. Addison-wesley Professional.
+- Kleppmann, M., 2017. Designing Data-intensive Applications: The Big Ideas Behind Reliable, Scalable,
+  And Maintainable Systems. O'reilly Media.
+- Martin R., C., 2019. Clean Agile: Back To Basics (robert C. Martin Series). Prentice Hall.
+- Martin R., C., 2009. Clean Code. Prentice Hall.
+- Martin R., C., 2011. The Clean Coder: A Code Of Conduct For Professional Programmers. Prentice Hall.
+- Negus, C., 2020. Linux Bible. Wiley.
+- Thompson, C., 2019. Coders: The Making Of A New Tribe And The Remaking Of The World.


### PR DESCRIPTION
- Configured `markdown` for list-item tab-size of 4
  - this is due to `showdown`
-  Updated `build.sh`
  - build `todo.html`
  - convert `:books:` emoji using `sed`
- Updated title and heading of `index` page
- Added key points and review (this is actually still WIP 🚧) for Clean Architecture